### PR TITLE
[Feat/#45] 다이어리 컨텐츠 프리뷰 컴포넌트 구현

### DIFF
--- a/main_project/src/components/common/Modal/MoodSelectModal.tsx
+++ b/main_project/src/components/common/Modal/MoodSelectModal.tsx
@@ -9,6 +9,7 @@ interface MoodSelectModalProps {
   isAnalysisFailed?: boolean;
   analyzedMood?: string;
   isDirectSelect?: boolean;
+  onSave: () => void;
 }
 
 const MoodSelectModal = ({
@@ -19,18 +20,29 @@ const MoodSelectModal = ({
   isAnalysisFailed = false,
   analyzedMood,
   isDirectSelect = false,
+  onSave,
 }: MoodSelectModalProps) => {
   const [selectedMoods, setSelectedMoods] = useState<string[]>([]);
 
   const handleMoodSelect = (mood: string) => {
     if (selectedMoods.includes(mood)) {
-      setSelectedMoods(selectedMoods.filter((m) => m !== mood));
+      if (selectedMoods.length > 1) {
+        setSelectedMoods(selectedMoods.filter((m) => m !== mood));
+        onSelect(mood);
+      }
     } else if (selectedMoods.length < 3) {
       setSelectedMoods([...selectedMoods, mood]);
       onSelect(mood);
-      // Todo: 감정 키워드 저장 후 모달 닫기 -> 일기 중간 작성 컴포넌트 추가 필요
-      onClose();
     }
+  };
+
+  const handleSave = () => {
+    if (selectedMoods.length === 0) {
+      alert("최소 1개의 감정을 선택해주세요.");
+      return;
+    }
+    onSave();
+    onClose();
   };
 
   return (
@@ -55,7 +67,7 @@ const MoodSelectModal = ({
 
         <div className="min-h-[200px] sm:h-[240px]">
           <div className="flex justify-between items-center mb-3">
-            <h2 className="text-base sm:text-lg text-gray-600 font-semibold">감정 키워드</h2>
+            <h2 className="text-base sm:text-lg text-gray-600 font-semibold">감정 키워드 선택</h2>
             <span className="text-xs sm:text-sm text-gray-500">
               {selectedMoods.length}/3 개의 감정을 선택했어요.
             </span>
@@ -80,7 +92,7 @@ const MoodSelectModal = ({
 
         <div className="flex justify-end">
           <button
-            onClick={onClose}
+            onClick={handleSave}
             className="px-6 sm:px-7 md:px-8 py-2 sm:py-2.5 bg-[#4A7196] text-white rounded-full hover:bg-[#3A5A7A] 
                       transition-colors text-xs sm:text-sm font-medium"
           >

--- a/main_project/src/components/diary/DiaryContent.tsx
+++ b/main_project/src/components/diary/DiaryContent.tsx
@@ -1,0 +1,80 @@
+import { formatDateKorean } from "../../utils/date";
+import { DiaryContent as DiaryContentType } from "../../models/diary";
+
+type DiaryViewProps = {
+  selectedDate: Date;
+  diaryContent: DiaryContentType;
+  onEdit: () => void;
+};
+
+const DiaryView = ({ selectedDate, diaryContent, onEdit }: DiaryViewProps) => {
+  const formattedDate = formatDateKorean(selectedDate);
+
+  return (
+    <div className="w-full max-w-6xl mx-auto px-4">
+      <div className="flex justify-between items-center mb-3">
+        <div className="text-medium text-[#5E8FBF] font-medium">{formattedDate}</div>
+        <button
+          onClick={onEdit}
+          className="text-gray-500 hover:text-gray-700 transition-colors"
+          aria-label="창닫기"
+        >
+          ✕
+        </button>
+      </div>
+
+      <div className="flex flex-col md:flex-row gap-4">
+        <div className="w-full md:w-[60%]">
+          <h2 className="text-base font-medium text-gray-800 mb-4 block border-b border-[#4A7196] px-1">
+            {diaryContent.title}
+          </h2>
+          <div className="border border-[#4A7196] rounded-lg p-3 h-[280px] bg-white overflow-y-auto">
+            <div className="prose prose-sm max-w-none h-full text-sm">
+              {diaryContent.content.split("\n").map((line, index) => (
+                <p key={index} className="mb-2">
+                  {line}
+                </p>
+              ))}
+            </div>
+          </div>
+        </div>
+
+        <div className="w-full md:w-[40%] flex flex-col justify-between md:pl-2.5 md:pt-10 mt-4 md:mt-0">
+          <div>
+            <h3 className="text-base text-gray-600 font-semibold mb-3">선택한 감정 키워드</h3>
+            <div className="flex flex-wrap gap-2">
+              {diaryContent.moods.map((mood, index) => (
+                <span
+                  key={index}
+                  className="px-4 py-1.5 bg-[#A6CCF2] text-white rounded-full text-sm font-medium min-w-[80px] text-center"
+                >
+                  {mood}
+                </span>
+              ))}
+            </div>
+          </div>
+
+          <div className="flex justify-end mt-4 md:mt-8">
+            <button className="px-4 py-2 bg-[#4A7196] text-white rounded-full hover:bg-[#3A5A7A] transition-colors text-sm font-medium flex items-center gap-2">
+              <span>필로디</span>
+              <svg
+                xmlns="http://www.w3.org/2000/svg"
+                className="h-4 w-4"
+                viewBox="0 0 20 20"
+                fill="currentColor"
+              >
+                <path
+                  fillRule="evenodd"
+                  d="M10.293 3.293a1 1 0 011.414 0l6 6a1 1 0 010 1.414l-6 6a1 1 0 01-1.414-1.414L14.586 11H3a1 1 0 110-2h11.586l-4.293-4.293a1 1 0 010-1.414z"
+                  clipRule="evenodd"
+                />
+              </svg>
+            </button>
+          </div>
+        </div>
+      </div>
+    </div>
+  );
+};
+
+export default DiaryView;

--- a/main_project/src/pages/DiaryContent.tsx
+++ b/main_project/src/pages/DiaryContent.tsx
@@ -1,13 +1,13 @@
-import { formatDateKorean } from "../../utils/date";
-import { DiaryContent as DiaryContentType } from "../../models/diary";
+import { formatDateKorean } from "../utils/date";
+import { DiaryContent as DiaryContentType } from "../models/diary";
 
-type DiaryViewProps = {
+type DiaryContentPreviewProps = {
   selectedDate: Date;
   diaryContent: DiaryContentType;
   onEdit: () => void;
 };
 
-const DiaryView = ({ selectedDate, diaryContent, onEdit }: DiaryViewProps) => {
+const DiaryContentPreview = ({ selectedDate, diaryContent, onEdit }: DiaryContentPreviewProps) => {
   const formattedDate = formatDateKorean(selectedDate);
 
   return (
@@ -41,7 +41,7 @@ const DiaryView = ({ selectedDate, diaryContent, onEdit }: DiaryViewProps) => {
 
         <div className="w-full md:w-[40%] flex flex-col justify-between md:pl-2.5 md:pt-10 mt-4 md:mt-0">
           <div>
-            <h3 className="text-base text-gray-600 font-semibold mb-3">선택한 감정 키워드</h3>
+            <h3 className="text-base text-gray-600 font-semibold mb-3">감정 키워드</h3>
             <div className="flex flex-wrap gap-2">
               {diaryContent.moods.map((mood, index) => (
                 <span
@@ -77,4 +77,4 @@ const DiaryView = ({ selectedDate, diaryContent, onEdit }: DiaryViewProps) => {
   );
 };
 
-export default DiaryView;
+export default DiaryContentPreview;

--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -1,6 +1,6 @@
 import { mockDiaries } from "../mock/diaryData";
 import DiaryList from "./DiaryList";
-import { formatDate, getTargetDateOrToday } from "../utils/date";
+import { formatDate, formatDateKorean, getTargetDateOrToday } from "../utils/date";
 import { SearchResult } from "../models/search";
 
 interface DiaryViewProps {
@@ -20,7 +20,6 @@ const DiaryView = ({
     (diary) => diary.date === formatDate(getTargetDateOrToday(selectedDate)),
   );
 
-  // 일기 내용 렌더링
   const renderDiaryContent = () => {
     if (!targetDiary) return null;
 
@@ -38,17 +37,28 @@ const DiaryView = ({
           <p className="text-xs text-gray-600">{targetDiary.rec_music.artist}</p>
         </div>
 
-        <p className="text-xs text-gray-500 text-right mt-2">
-          {targetDiary.date} | {targetDiary.moods.join(", ")}
-        </p>
+        <div className="flex justify-between items-start mb-4 mt-8 ">
+          <div className="text-sm text-[#4A7196] font-semibold">
+            {formatDateKorean(getTargetDateOrToday(selectedDate))}
+          </div>
+          <div className="flex gap-2">
+            {targetDiary.moods.map((mood, index) => (
+              <span
+                key={index}
+                className="px-3 py-1 bg-[#4A7196] text-white rounded-full text-xs font-medium shadow-sm"
+              >
+                {mood}
+              </span>
+            ))}
+          </div>
+        </div>
 
-        <p className="text-base font-semibold mt-3">{targetDiary.title}</p>
+        <p className="text-base font-semibold mt-3 mb-1">{targetDiary.title}</p>
         <p className="text-sm text-gray-700">{targetDiary.content}</p>
       </div>
     );
   };
 
-  // 작성하기 버튼 렌더링
   const renderWriteButton = () => (
     <div className="w-full flex items-center justify-center">
       <button

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -4,7 +4,7 @@ import StarterKit from "@tiptap/starter-kit";
 import { formatDateKorean } from "../utils/date";
 import { DiaryContent, Mood } from "../models/diary";
 import MoodSelectModal from "../components/common/Modal/MoodSelectModal";
-import DiaryView from "../components/diary/DiaryContent";
+import DiaryContentPreview from "./DiaryContent";
 
 interface DiaryWriteProps {
   selectedDate: Date;
@@ -141,7 +141,11 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
 
   if (isSaved) {
     return (
-      <DiaryView selectedDate={selectedDate} diaryContent={diaryContent} onEdit={handleEdit} />
+      <DiaryContentPreview
+        selectedDate={selectedDate}
+        diaryContent={diaryContent}
+        onEdit={handleEdit}
+      />
     );
   }
 

--- a/main_project/src/utils/date.ts
+++ b/main_project/src/utils/date.ts
@@ -1,7 +1,12 @@
 import dayjs from "dayjs";
+import "dayjs/locale/ko";
 
 export const formatDate = (date: Date): string => {
   return dayjs(date).format("YYYY-MM-DD");
+};
+
+export const formatDateKorean = (date: Date): string => {
+  return dayjs(date).locale("ko").format("YYYY년 MM월 DD일 (ddd)");
 };
 
 export const getToday = (): Date => {


### PR DESCRIPTION
다이어리 컨텐츠 컴포넌트 구현

## #️⃣연관된 이슈

> #45 

## 📝작업 내용

> 해당날짜, 일기제목과 내용, 선택한 감정 키워드 프리뷰 컴포넌트
> 다이어리 관련 UI 수정
> 다이어리 작성 컴포넌트에서 제목과 내용 작성 안할시, 버튼 실행되지 않게 수정

### 스크린샷 (선택)
![스크린샷 2025-03-24 오후 11 54 17](https://github.com/user-attachments/assets/eb9924dc-446a-41b8-83fe-fd8e4412cf45)
![스크린샷 2025-03-24 오후 11 55 48](https://github.com/user-attachments/assets/3615b56f-390e-486e-9063-f1d8b8c52ec3)
![스크린샷 2025-03-24 오후 11 56 10](https://github.com/user-attachments/assets/7f679b75-d42f-4419-b79d-17eaafdfdabe)
![스크린샷 2025-03-24 오후 11 54 42](https://github.com/user-attachments/assets/bbf41d45-dc76-4cfd-9bd7-cd4c81d65bd0)
![스크린샷 2025-03-24 오후 11 52 44](https://github.com/user-attachments/assets/d76e10f9-33ca-4f89-bd46-c93fca64741a)
![스크린샷 2025-03-24 오후 11 53 29](https://github.com/user-attachments/assets/e28f4945-461d-4949-9b02-a994f31a47f3)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
