### PR TITLE
[Feat/#85] 탭 분리

### DIFF
--- a/main_project/package-lock.json
+++ b/main_project/package-lock.json
@@ -8,6 +8,7 @@
       "name": "main_project",
       "version": "0.0.0",
       "dependencies": {
+        "@tanstack/react-query": "^5.69.0",
         "@tiptap/pm": "^2.11.5",
         "@tiptap/react": "^2.11.5",
         "@tiptap/starter-kit": "^2.11.5",
@@ -1671,6 +1672,32 @@
       },
       "peerDependencies": {
         "vite": "^5.2.0 || ^6"
+      }
+    },
+    "node_modules/@tanstack/query-core": {
+      "version": "5.69.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.69.0.tgz",
+      "integrity": "sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==",
+      "license": "MIT",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      }
+    },
+    "node_modules/@tanstack/react-query": {
+      "version": "5.69.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.69.0.tgz",
+      "integrity": "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==",
+      "license": "MIT",
+      "dependencies": {
+        "@tanstack/query-core": "5.69.0"
+      },
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/tannerlinsley"
+      },
+      "peerDependencies": {
+        "react": "^18 || ^19"
       }
     },
     "node_modules/@tiptap/core": {

--- a/main_project/package.json
+++ b/main_project/package.json
@@ -12,6 +12,7 @@
     "format": "prettier --write \"src/**/*.{js,jsx,ts,tsx,css,md}\""
   },
   "dependencies": {
+    "@tanstack/react-query": "^5.69.0",
     "@tiptap/pm": "^2.11.5",
     "@tiptap/react": "^2.11.5",
     "@tiptap/starter-kit": "^2.11.5",

--- a/main_project/src/components/common/SearchBar.tsx
+++ b/main_project/src/components/common/SearchBar.tsx
@@ -9,6 +9,7 @@ interface SearchBarProps {
   setShowSearch: (show: boolean) => void;
   handleSearchInputRef: (element: HTMLInputElement | null) => void;
   isSearching: boolean;
+  tabIndex: number; // Added tabIndex to the interface
 }
 
 const SearchBar = ({
@@ -20,8 +21,9 @@ const SearchBar = ({
   setShowSearch,
   handleSearchInputRef,
   isSearching,
+  tabIndex,
 }: SearchBarProps) => {
-  return (
+  return tabIndex === 0 ? (
     <>
       {showSearch ? (
         <div className="relative flex items-center">
@@ -53,7 +55,7 @@ const SearchBar = ({
         </button>
       )}
     </>
-  );
+  ) : null;
 };
 
 export default SearchBar;

--- a/main_project/src/components/common/TopBar.tsx
+++ b/main_project/src/components/common/TopBar.tsx
@@ -1,0 +1,60 @@
+import SearchBar from "./SearchBar";
+import UserMenu from "./UserMenu";
+import { RefObject } from "react";
+
+interface TopBarProps {
+  showSearch: boolean;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  handleSearch: (e: React.KeyboardEvent<HTMLInputElement>) => Promise<void>;
+  clearSearch: () => void;
+  setShowSearch: (show: boolean) => void;
+  handleSearchInputRef: (element: HTMLInputElement | null) => void;
+  isSearching: boolean;
+
+  showDropdown: boolean;
+  setShowDropdown: (show: boolean) => void;
+  dropdownRef: RefObject<HTMLDivElement | null>;
+  handleOpenProfile: () => void;
+  handleOpenLogoutConfirm: () => void;
+}
+
+const TopBar = ({
+  showSearch,
+  searchQuery,
+  setSearchQuery,
+  handleSearch,
+  clearSearch,
+  setShowSearch,
+  handleSearchInputRef,
+  isSearching,
+  showDropdown,
+  setShowDropdown,
+  dropdownRef,
+  handleOpenProfile,
+  handleOpenLogoutConfirm,
+}: TopBarProps) => {
+  return (
+    <div className="flex items-center gap-2 ml-auto">
+      <SearchBar
+        showSearch={showSearch}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        handleSearch={handleSearch}
+        clearSearch={clearSearch}
+        setShowSearch={setShowSearch}
+        handleSearchInputRef={handleSearchInputRef}
+        isSearching={isSearching}
+      />
+      <UserMenu
+        showDropdown={showDropdown}
+        setShowDropdown={setShowDropdown}
+        dropdownRef={dropdownRef}
+        handleOpenProfile={handleOpenProfile}
+        handleOpenLogoutConfirm={handleOpenLogoutConfirm}
+      />
+    </div>
+  );
+};
+
+export default TopBar;

--- a/main_project/src/components/common/TopBar.tsx
+++ b/main_project/src/components/common/TopBar.tsx
@@ -3,6 +3,7 @@ import UserMenu from "./UserMenu";
 import { RefObject } from "react";
 
 interface TopBarProps {
+  tabIndex: number;
   showSearch: boolean;
   searchQuery: string;
   setSearchQuery: (query: string) => void;
@@ -20,6 +21,7 @@ interface TopBarProps {
 }
 
 const TopBar = ({
+  tabIndex,
   showSearch,
   searchQuery,
   setSearchQuery,
@@ -37,6 +39,7 @@ const TopBar = ({
   return (
     <div className="flex items-center gap-2 ml-auto">
       <SearchBar
+        tabIndex={tabIndex}
         showSearch={showSearch}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}

--- a/main_project/src/components/common/TopBarContainer.tsx
+++ b/main_project/src/components/common/TopBarContainer.tsx
@@ -8,6 +8,7 @@ import { axiosFetcher } from "../../api/axiosFetcher";
 import authApi from "../../api/Authapi";
 
 interface TopBarContainerProps {
+  tabIndex: number;
   showSearch: boolean;
   setShowSearch: (show: boolean) => void;
   searchQuery: string;
@@ -19,6 +20,7 @@ interface TopBarContainerProps {
 }
 
 const TopBarContainer = ({
+  tabIndex,
   showSearch,
   setShowSearch,
   searchQuery,
@@ -98,6 +100,7 @@ const TopBarContainer = ({
   return (
     <>
       <TopBar
+        tabIndex={tabIndex}
         showSearch={showSearch}
         searchQuery={searchQuery}
         setSearchQuery={setSearchQuery}

--- a/main_project/src/components/common/TopBarContainer.tsx
+++ b/main_project/src/components/common/TopBarContainer.tsx
@@ -1,0 +1,135 @@
+import { useState, useRef, useEffect } from "react";
+import TopBar from "./TopBar";
+import ProfileModal from "./Modal/ProfileModal";
+import CustomConfirmModal from "./Modal/CustomConfirmModal";
+import { useAuthStore } from "../../store/useAuthStore";
+import { useNavigate } from "react-router-dom";
+import { axiosFetcher } from "../../api/axiosFetcher";
+import authApi from "../../api/Authapi";
+
+interface TopBarContainerProps {
+  showSearch: boolean;
+  setShowSearch: (show: boolean) => void;
+  searchQuery: string;
+  setSearchQuery: (query: string) => void;
+  isSearching: boolean;
+  clearSearch: () => void;
+  handleSearchInputRef: (el: HTMLInputElement | null) => void;
+  handleSearch: (e: React.KeyboardEvent<HTMLInputElement>) => Promise<void>;
+}
+
+const TopBarContainer = ({
+  showSearch,
+  setShowSearch,
+  searchQuery,
+  setSearchQuery,
+  isSearching,
+  clearSearch,
+  handleSearchInputRef,
+  handleSearch,
+}: TopBarContainerProps) => {
+  const [showDropdown, setShowDropdown] = useState(false);
+  const dropdownRef = useRef<HTMLDivElement | null>(null);
+  const [isProfileOpen, setIsProfileOpen] = useState(false);
+  const [showLogoutModal, setShowLogoutModal] = useState(false);
+  const { refreshToken, clearAuth } = useAuthStore.getState();
+  const navigate = useNavigate();
+
+  const [modalUser, setModalUser] = useState({
+    nickname: "",
+    profileImage: "",
+    introduction: "",
+    preferredGenres: [] as string[],
+  });
+
+  const handleClickOutside = (event: MouseEvent) => {
+    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
+      setShowDropdown(false);
+    }
+  };
+
+  useEffect(() => {
+    document.addEventListener("mousedown", handleClickOutside);
+    return () => document.removeEventListener("mousedown", handleClickOutside);
+  }, []);
+
+  const handleOpenProfile = async () => {
+    try {
+      const res = await axiosFetcher.get<{
+        profile_image: string;
+        member: {
+          nickname: string;
+          introduce: string;
+          favorite_genre: string[];
+        };
+      }>("api/members/profile/");
+
+      setModalUser({
+        nickname: res.member.nickname ?? "",
+        profileImage: res.profile_image ?? "",
+        introduction: res.member.introduce ?? "",
+        preferredGenres: res.member.favorite_genre ?? [],
+      });
+
+      setIsProfileOpen(true);
+    } catch (error) {
+      console.error("프로필 불러오기 실패:", error);
+      alert("프로필 정보를 불러오는데 실패했어요.");
+    }
+  };
+
+  const handleLogout = async () => {
+    try {
+      if (!refreshToken) {
+        alert("유효하지 않은 토큰입니다. 다시 로그인해주세요.");
+        return;
+      }
+
+      await authApi.logout({ refresh_token: refreshToken });
+      clearAuth();
+      alert("로그아웃되었습니다.");
+      navigate("/");
+    } catch (error) {
+      console.error("로그아웃 실패:", error);
+      alert("로그아웃 중 오류가 발생했습니다.");
+    }
+  };
+
+  return (
+    <>
+      <TopBar
+        showSearch={showSearch}
+        searchQuery={searchQuery}
+        setSearchQuery={setSearchQuery}
+        handleSearch={handleSearch}
+        clearSearch={clearSearch}
+        setShowSearch={setShowSearch}
+        handleSearchInputRef={handleSearchInputRef}
+        isSearching={isSearching}
+        showDropdown={showDropdown}
+        setShowDropdown={setShowDropdown}
+        dropdownRef={dropdownRef}
+        handleOpenProfile={handleOpenProfile}
+        handleOpenLogoutConfirm={() => setShowLogoutModal(true)}
+      />
+      <ProfileModal
+        isOpen={isProfileOpen}
+        onClose={() => setIsProfileOpen(false)}
+        user={modalUser}
+      />
+      <CustomConfirmModal
+        type="logout"
+        title="로그아웃 하시겠습니까?"
+        message="로그아웃하면 다시 로그인해야 해요"
+        isOpen={showLogoutModal}
+        onClose={() => setShowLogoutModal(false)}
+        onConfirm={handleLogout}
+        isDanger
+        confirmText="로그아웃"
+        cancelText="취소"
+      />
+    </>
+  );
+};
+
+export default TopBarContainer;

--- a/main_project/src/components/common/UserMenu.tsx
+++ b/main_project/src/components/common/UserMenu.tsx
@@ -4,8 +4,9 @@ import { useNavigate } from "react-router-dom";
 interface UserMenuProps {
   showDropdown: boolean;
   setShowDropdown: (show: boolean) => void;
-  dropdownRef: React.RefObject<HTMLDivElement>;
+  dropdownRef: React.RefObject<HTMLDivElement | null>;
   handleOpenProfile: () => void;
+  handleOpenLogoutConfirm: () => void;
 }
 
 const UserMenu = ({
@@ -13,6 +14,7 @@ const UserMenu = ({
   setShowDropdown,
   dropdownRef,
   handleOpenProfile,
+  handleOpenLogoutConfirm,
 }: UserMenuProps) => {
   const navigate = useNavigate();
 
@@ -42,9 +44,7 @@ const UserMenu = ({
             <span>마이페이지</span>
           </button>
           <button
-            onClick={() => {
-              // TODO: 로그아웃 기능 구현
-            }}
+            onClick={handleOpenLogoutConfirm}
             className="w-full px-4 py-2 text-left text-sm text-red-600 hover:bg-gray-100 flex items-center gap-2"
           >
             <FaSignOutAlt size={14} />

--- a/main_project/src/components/common/tabs.tsx
+++ b/main_project/src/components/common/tabs.tsx
@@ -4,8 +4,11 @@ import DiaryHome from "../../pages/DiaryHome";
 import MoodChart from "../../pages/moodChart";
 import TopBarContainer from "./TopBarContainer";
 import { useSearch } from "../../hooks/useSearch";
+import { useState } from "react";
 
 function MyTabs() {
+  const [tabIndex, setTabIndex] = useState(0);
+
   const {
     showSearch,
     setShowSearch,
@@ -19,7 +22,11 @@ function MyTabs() {
   } = useSearch();
 
   return (
-    <Tabs className="bg-[#A6CCF2] min-h-screen flex flex-col" defaultIndex={0}>
+    <Tabs
+      className="bg-[#A6CCF2] min-h-screen flex flex-col"
+      selectedIndex={tabIndex}
+      onSelect={(index) => setTabIndex(index)}
+    >
       <TabList className="flex max-w-[1130px] w-full mx-auto pt-0 pr-4 pl-7 items-center">
         <Tab
           className="px-4 py-3 text-gray-700 hover:text-black focus:outline-none whitespace-nowrap text-sm cursor-pointer"
@@ -34,6 +41,7 @@ function MyTabs() {
           나의 감정발자취
         </Tab>
         <TopBarContainer
+          tabIndex={tabIndex}
           showSearch={showSearch}
           setShowSearch={setShowSearch}
           searchQuery={searchQuery}

--- a/main_project/src/components/common/tabs.tsx
+++ b/main_project/src/components/common/tabs.tsx
@@ -2,97 +2,21 @@ import { Tab, TabList, TabPanel, Tabs } from "react-tabs";
 import "react-tabs/style/react-tabs.css";
 import DiaryHome from "../../pages/DiaryHome";
 import MoodChart from "../../pages/moodChart";
-import { useState, useRef, useEffect, RefObject } from "react";
-import ProfileModal from "./Modal/ProfileModal";
-import { axiosFetcher } from "../../api/axiosFetcher";
-import { useAuthStore } from "../../store/useAuthStore";
+import TopBarContainer from "./TopBarContainer";
 import { useSearch } from "../../hooks/useSearch";
-import SearchBar from "./SearchBar";
-import UserMenu from "./UserMenu";
-import { useNavigate } from "react-router-dom";
-import authApi from "../../api/authApi";
-import CustomConfirmModal from "./Modal/CustomConfirmModal";
 
 function MyTabs() {
-  const [showDropdown, setShowDropdown] = useState(false);
-  const { refreshToken, clearAuth } = useAuthStore.getState();
-  const dropdownRef = useRef<HTMLDivElement | null>(null);
-  const [isProfileOpen, setIsProfileOpen] = useState(false);
-  const [showLogoutModal, setShowLogoutModal] = useState(false);
-  const navigate = useNavigate();
   const {
     showSearch,
     setShowSearch,
     searchQuery,
     setSearchQuery,
     isSearching,
-    searchResults,
     clearSearch,
     handleSearchInputRef,
     handleSearch,
+    searchResults,
   } = useSearch();
-
-  const [modalUser, setModalUser] = useState({
-    nickname: "",
-    profileImage: "",
-    introduction: "",
-    preferredGenres: [] as string[],
-  });
-
-  const handleClickOutside = (event: MouseEvent) => {
-    if (dropdownRef.current && !dropdownRef.current.contains(event.target as Node)) {
-      setShowDropdown(false);
-    }
-  };
-
-  useEffect(() => {
-    document.addEventListener("mousedown", handleClickOutside);
-    return () => document.removeEventListener("mousedown", handleClickOutside);
-  }, []);
-
-  const handleOpenProfile = async () => {
-    try {
-      const res = await axiosFetcher.get<{
-        profile_image: string;
-        member: {
-          nickname: string;
-          introduce: string;
-          favorite_genre: string[];
-        };
-      }>("api/members/profile/");
-      console.log("프로필 API 응답:", res);
-
-      setModalUser({
-        nickname: res.member.nickname ?? "",
-        profileImage: res.profile_image ?? "",
-        introduction: res.member.introduce ?? "",
-        preferredGenres: res.member.favorite_genre ?? [],
-      });
-
-      setIsProfileOpen(true);
-    } catch (error) {
-      console.error("프로필 불러오기 실패:", error);
-      alert("프로필 정보를 불러오는데 실패했어요.");
-    }
-  };
-
-  const handleLogout = async () => {
-    try {
-      if (!refreshToken) {
-        alert("유효하지 않은 토큰입니다. 다시 로그인해주세요.");
-        return;
-      }
-
-      await authApi.logout({ refresh_token: refreshToken });
-
-      clearAuth();
-      alert("로그아웃되었습니다.");
-      navigate("/");
-    } catch (error) {
-      console.error("로그아웃 실패:", error);
-      alert("로그아웃 중 오류가 발생했습니다.");
-    }
-  };
 
   return (
     <Tabs className="bg-[#A6CCF2] min-h-screen flex flex-col" defaultIndex={0}>
@@ -109,24 +33,16 @@ function MyTabs() {
         >
           나의 감정발자취
         </Tab>
-        <div className="flex items-center gap-2 ml-auto">
-          <SearchBar
-            showSearch={showSearch}
-            searchQuery={searchQuery}
-            setSearchQuery={setSearchQuery}
-            handleSearch={handleSearch}
-            clearSearch={clearSearch}
-            setShowSearch={setShowSearch}
-            handleSearchInputRef={handleSearchInputRef}
-            isSearching={isSearching}
-          />
-          <UserMenu
-            showDropdown={showDropdown}
-            setShowDropdown={setShowDropdown}
-            dropdownRef={dropdownRef as RefObject<HTMLDivElement>}
-            handleOpenProfile={handleOpenProfile}
-          />
-        </div>
+        <TopBarContainer
+          showSearch={showSearch}
+          setShowSearch={setShowSearch}
+          searchQuery={searchQuery}
+          setSearchQuery={setSearchQuery}
+          isSearching={isSearching}
+          clearSearch={clearSearch}
+          handleSearchInputRef={handleSearchInputRef}
+          handleSearch={handleSearch}
+        />
       </TabList>
 
       <div className="w-full max-w-[1130px] mx-auto">
@@ -141,23 +57,6 @@ function MyTabs() {
           <MoodChart />
         </TabPanel>
       </div>
-
-      <ProfileModal
-        isOpen={isProfileOpen}
-        onClose={() => setIsProfileOpen(false)}
-        user={modalUser}
-      />
-      <CustomConfirmModal
-        type="logout"
-        title="로그아웃 하시겠습니까?"
-        message="로그아웃하면 다시 로그인해야 해요"
-        isOpen={showLogoutModal}
-        onClose={() => setShowLogoutModal(false)}
-        onConfirm={handleLogout}
-        isDanger
-        confirmText="로그아웃"
-        cancelText="취소"
-      />
     </Tabs>
   );
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #85 

## 📝작업 내용

> 탭에서 검색바와 사용자메뉴를 분리하였고, 나의 감정발자취탭에서는 검색바를 보이지 않게 수정하였 나의 감정기록 탭에서만 검색이 가능하도록 수정하였습니다.

### 스크린샷 (선택)
<img width="1152" alt="스크린샷 2025-03-30 오후 11 06 38" src="https://github.com/user-attachments/assets/db267b52-4b5f-46c8-8616-1506f504edf5" />
<img width="1168" alt="스크린샷 2025-03-30 오후 11 06 55" src="https://github.com/user-attachments/assets/d541a96b-7f13-4d81-b340-746f66668351" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
