### PR TITLE
[Feat/#81] 일기 작성 리팩토링

### DIFF
--- a/main_project/src/pages/DiaryHome.tsx
+++ b/main_project/src/pages/DiaryHome.tsx
@@ -48,9 +48,10 @@ const DiaryHome = ({ searchQuery = "", searchResults = [], onClearSearch }: Diar
     staleTime: 1000 * 60 * 10, // 10 minutes
   });
 
-  const diaryDates = (diaryData ?? []).map((item) => item.date);
+  const diaryDates = diaryData?.map((item) => item.date) || [];
+
   const diaryIdMap: Record<string, string> = {};
-  (diaryData ?? []).forEach((item) => {
+  diaryData?.forEach((item) => {
     diaryIdMap[item.date] = item.diary_id;
   });
 

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -32,7 +32,6 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
   });
   const [analyzedKeywords, setAnalyzedKeywords] = useState<string[]>([]);
   const [isMoodModalOpen, setIsMoodModalOpen] = useState(false);
-  const [isAnalysisFailed, setIsAnalysisFailed] = useState(false);
   const [isDirectSelect, setIsDirectSelect] = useState(false);
   const [isSaved, setIsSaved] = useState(false);
 
@@ -43,13 +42,11 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
     onSuccess: (res) => {
       console.log("추천받은 감정 키워드:", res);
       setAnalyzedKeywords(res || []);
-      setIsAnalysisFailed(false);
-      closeModal();
-      setIsDirectSelect(false);
-      setIsMoodModalOpen(true);
     },
     onError: () => {
-      setIsAnalysisFailed(true);
+      setAnalyzedKeywords([]);
+    },
+    onSettled: () => {
       closeModal();
       setIsDirectSelect(false);
       setIsMoodModalOpen(true);
@@ -76,7 +73,6 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
   };
 
   const handleEmotionSelect = () => {
-    setIsAnalysisFailed(false);
     setIsDirectSelect(true);
     setIsMoodModalOpen(true);
   };
@@ -112,7 +108,6 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
 
   const handleSave = async () => {
     try {
-      // 기록 저장 시 로딩 모달 표시 추가
       openModal("loading", {
         message: "기록을 저장중이에요",
         modalPurpose: "saving",
@@ -139,11 +134,11 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
 
       setIsSaved(true);
 
-      closeModal(); // 저장 완료 후 로딩 모달 닫기 추가
+      closeModal();
     } catch (error) {
       console.error("일기 저장 중 오류 발생:", error);
 
-      closeModal(); // 에러 발생 시에도 로딩 모달 닫기 추가
+      closeModal();
     }
   };
 
@@ -223,7 +218,7 @@ const DiaryWrite = ({ selectedDate, onCancel }: DiaryWriteProps) => {
         onClose={() => setIsMoodModalOpen(false)}
         onSelect={(mood: Mood) => handleMoodSelect(mood)}
         moods={Object.values(Mood)}
-        isAnalysisFailed={isAnalysisFailed}
+        isAnalysisFailed={analyzedKeywords.length === 0 && !isDirectSelect}
         isDirectSelect={isDirectSelect}
         onSave={handleSave}
         analyzedKeywords={analyzedKeywords}

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,13 +5,13 @@
   "packages": {
     "": {
       "dependencies": {
-        "@tanstack/react-query": "^5.69.0"
+        "@tanstack/react-query": "^5.71.0"
       }
     },
     "node_modules/@tanstack/query-core": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.69.0.tgz",
-      "integrity": "sha512-Kn410jq6vs1P8Nm+ZsRj9H+U3C0kjuEkYLxbiCyn3MDEiYor1j2DGVULqAz62SLZtUZ/e9Xt6xMXiJ3NJ65WyQ==",
+      "version": "5.71.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/query-core/-/query-core-5.71.0.tgz",
+      "integrity": "sha512-p4+T7CIEe1kMhii4booWiw42nuaiYI9La/bRCNzBaj1P3PDb0dEZYDhc/7oBifKJfHYN+mtS1ynW1qsmzQW7Og==",
       "license": "MIT",
       "funding": {
         "type": "github",
@@ -19,12 +19,12 @@
       }
     },
     "node_modules/@tanstack/react-query": {
-      "version": "5.69.0",
-      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.69.0.tgz",
-      "integrity": "sha512-Ift3IUNQqTcaFa1AiIQ7WCb/PPy8aexZdq9pZWLXhfLcLxH0+PZqJ2xFImxCpdDZrFRZhLJrh76geevS5xjRhA==",
+      "version": "5.71.0",
+      "resolved": "https://registry.npmjs.org/@tanstack/react-query/-/react-query-5.71.0.tgz",
+      "integrity": "sha512-Udhlz9xHwk0iB7eLDchIqvu666NZFxPZZF80KnL8sZy+5J0kMvnJkzQNYRJwF70g8Vc1nn0TSMkPJgvx6+Pn4g==",
       "license": "MIT",
       "dependencies": {
-        "@tanstack/query-core": "5.69.0"
+        "@tanstack/query-core": "5.71.0"
       },
       "funding": {
         "type": "github",

--- a/package.json
+++ b/package.json
@@ -1,5 +1,5 @@
 {
   "dependencies": {
-    "@tanstack/react-query": "^5.69.0"
+    "@tanstack/react-query": "^5.71.0"
   }
 }


### PR DESCRIPTION
## #️⃣연관된 이슈

> #81 

## 📝작업 내용

> isAnalysisFailed는 없애고, analyzedKeywords.length === 0 && !isDirectSelect로 수정하여 감정분석을 시도했지만, 분석 실패한 경우를 알 수 있도록 했습니다.
setIsDirectSelect는 모달에서 보여주는 UI가 달라서 어떤 버튼의 경로로 들어왔는지 구분이 필요해 남겨두었습니다.
setIsMoodModalOpen은 아래와 같이 수정하여 성공/실패와 상관없이 마지막에 실행될 수 있게했습니다.
분석 중 띄워뒀던 로딩 모달을 닫고 직접 선택이 아님을 보여주고 감정선택모달을 열어줍니다.
onSettled: () => {
closeModal();
setIsDirectSelect(false);
setIsMoodModalOpen(true);
},
다이어리홈에서 const diaryDates = (diaryData ?? []).map((item) => item.date); 코드를 const diaryDates = diartData?.map((item) => item.date) || []; 로 수정했습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
