### PR TITLE
[Feat/#79] 감정 직접 선택 모달 수정

### DIFF
--- a/main_project/src/components/common/Modal/MoodSelectModal.tsx
+++ b/main_project/src/components/common/Modal/MoodSelectModal.tsx
@@ -20,6 +20,7 @@ const MoodSelectModal = ({
   moods,
   isAnalysisFailed = false,
   analyzedKeywords,
+  isDirectSelect = false,
   onSave,
 }: MoodSelectModalProps) => {
   const [selectedMoods, setSelectedMoods] = useState<Mood[]>([]);
@@ -81,8 +82,7 @@ const MoodSelectModal = ({
           </div>
         ) : null}
 
-        {/* 기본 감정 키워드 */}
-        {isAnalysisFailed && (
+        {(isAnalysisFailed || isDirectSelect) && (
           <div className="min-h-[200px] sm:h-[240px]">
             <div className="flex justify-between items-center mb-3">
               <h2 className="text-base sm:text-lg text-gray-600 font-semibold">감정 키워드</h2>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #79 

## 📝작업 내용

> 감정 분석 api를 수정하면서 감정 직접 선택 관련 코드가 같이 수정되어 감정 키워드 버튼이 보이지 않는 이슈가 발생하여 다시 보이도록 수정하였습니다.

### 스크린샷 (선택)
<img width="1150" alt="스크린샷 2025-03-31 오전 2 11 25" src="https://github.com/user-attachments/assets/167e89cd-de64-4dbe-b619-a024d0e9b819" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
