### PR TITLE
[Feat/#6] 당일 날짜 선택 후, 감정 기록 버튼 클릭 시 발생하는 오류 수정

### DIFF
--- a/main_project/src/components/Calendar/Calendar.tsx
+++ b/main_project/src/components/Calendar/Calendar.tsx
@@ -1,8 +1,7 @@
-import { useState } from "react";
 import Calendar from "react-calendar";
 import "dayjs/locale/ko";
 import "../Calendar/calendar.css";
-import { formatDate, getToday } from "../../utils/date";
+import { formatDate } from "../../utils/date";
 export interface MyCalendarProps {
   selectedDate: Date | null;
   onDateSelect: (date: Date | null) => void;
@@ -10,15 +9,11 @@ export interface MyCalendarProps {
 }
 
 const MyCalendar = ({ selectedDate, onDateSelect, diaryDates }: MyCalendarProps) => {
-  const [date, setDate] = useState<Date | null>(selectedDate || getToday());
-
   const handleDateChange = (newDate: Date | null) => {
     if (newDate instanceof Date) {
-      if (date && formatDate(date) === formatDate(newDate)) {
-        setDate(null);
+      if (selectedDate && formatDate(selectedDate) === formatDate(newDate)) {
         onDateSelect(null);
       } else {
-        setDate(newDate);
         onDateSelect(newDate);
       }
     }
@@ -28,7 +23,7 @@ const MyCalendar = ({ selectedDate, onDateSelect, diaryDates }: MyCalendarProps)
     <div className="w-full h-[374px] overflow-hidden flex justify-center items-center">
       <Calendar
         onChange={(value) => value instanceof Date && handleDateChange(value)}
-        value={date}
+        value={selectedDate}
         locale="ko"
         calendarType="gregory"
         prev2Label={null}

--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -27,6 +27,7 @@ const DiaryView = ({
 }: DiaryViewProps) => {
   const { openModal } = useModalStore();
   const [diary, setDiary] = useState<Diary | null>(null);
+  const [showDateWarning, setShowDateWarning] = useState(false);
 
   const handleDeleteDiary = async () => {
     if (!selectedDate) return;
@@ -67,7 +68,6 @@ const DiaryView = ({
         <div className="flex justify-end mb-2">
           <button
             onClick={() => {
-              // 컨펌 모달 코드 추가
               openModal("customConfirm", {
                 title: "기록을 삭제할까요?",
                 message: "삭제하고 나면 되돌릴 수 없어요!",
@@ -131,13 +131,21 @@ const DiaryView = ({
   };
 
   const renderWriteButton = () => (
-    <div className="w-full flex items-center justify-center">
+    <div className="w-full flex flex-col items-center justify-center gap-2">
       <button
-        onClick={onWriteClick}
+        onClick={() => {
+          if (!selectedDate) {
+            setShowDateWarning(true);
+            return;
+          }
+          setShowDateWarning(false);
+          onWriteClick();
+        }}
         className="border border-black py-1 px-2 text-xs rounded-full active:scale-95 transition-transform duration-150 cursor-pointer"
       >
         + 감정 기록 작성하기
       </button>
+      {showDateWarning && <p className="text-xs text-red-500">날짜를 선택해주세요!</p>}
     </div>
   );
 

--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -141,11 +141,11 @@ const DiaryView = ({
           setShowDateWarning(false);
           onWriteClick();
         }}
-        className="border border-black py-1 px-2 text-xs rounded-full active:scale-95 transition-transform duration-150 cursor-pointer"
+        className="border border-black py-2 px-4 text-sm rounded-full active:scale-95 transition-transform duration-150 cursor-pointer"
       >
         + 감정 기록 작성하기
       </button>
-      {showDateWarning && <p className="text-xs text-red-500">날짜를 선택해주세요!</p>}
+      {showDateWarning && <p className="text-sm text-red-500">날짜를 선택해주세요!</p>}
     </div>
   );
 


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 기존 코드에서는 당일 날짜 선택 후, 감정 기록 작성하기 버튼 클릭 시 다시 날짜를 클릭해야하는 오류가 있어서 MyCalendar는 상위에서 내려온 selectedDate만 사용하도록 해 날짜 선택 시 즉시 반영될 수 있도록 수정하였습니다.  추가로 날짜 선택하지 않고, 버튼을 눌렀을 시 날짜를 선택하라는 메세지가 나오도록 추가하였습니다.
그리고 감정기록 버튼의 크기를 조금 키웠습니다.

### 스크린샷 (선택)
<img width="1152" alt="스크린샷 2025-03-31 오전 2 43 03" src="https://github.com/user-attachments/assets/9eb7358d-3bc9-4361-a2bf-8a4bd6cb3391" />


## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
