### PR TITLE
[Feat/#24] 일기리스트 UI 수정 & 뒤로가기  추가

### DIFF
--- a/main_project/src/pages/DiaryHome.tsx
+++ b/main_project/src/pages/DiaryHome.tsx
@@ -80,6 +80,7 @@ const DiaryHome = ({ searchQuery = "", searchResults = [], onClearSearch }: Diar
                 setSelectedDiaryId(id);
                 setSelectedDate(new Date(date));
               }}
+              onBackToList={() => setSelectedDiaryId(null)}
             />
           }
         />

--- a/main_project/src/pages/DiaryList.tsx
+++ b/main_project/src/pages/DiaryList.tsx
@@ -29,21 +29,29 @@ const DiaryList = ({ diaries, onDiarySelect }: DiaryListProps) => {
               </span>
             </div>
 
-            <div className="mt-1 flex items-center gap-2">
-              <span className="text-xs text-gray-500">감정: {diary.moods.join(", ")}</span>
+            <div className="mt-1 flex justify-between items-center flex-wrap">
               {diary.rec_music && (
-                <>
-                  <span className="text-xs text-gray-500">음악: {diary.rec_music.title}</span>
-                  {/* 음악 썸네일 추가 */}
+                <div className="flex items-center gap-2">
                   {diary.rec_music.thumbnail && (
                     <img
                       src={diary.rec_music.thumbnail}
                       alt={diary.rec_music.title}
-                      className="w-8 h-8 object-cover rounded ml-1 border border-gray-200"
+                      className="w-8 h-8 object-cover rounded border border-gray-200"
                     />
                   )}
-                </>
+                  <span className="text-xs text-gray-500">{diary.rec_music.title}</span>
+                </div>
               )}
+              <div className="flex flex-wrap gap-1">
+                {diary.moods.map((mood, index) => (
+                  <span
+                    key={index}
+                    className="bg-blue-100 text-black text-xs font-medium px-2 py-0.5 rounded-full"
+                  >
+                    {mood}
+                  </span>
+                ))}
+              </div>
             </div>
           </div>
         ))}

--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -14,6 +14,7 @@ interface DiaryViewProps {
   diaryIdMap: Record<string, string>;
   selectedDiaryId: string | null;
   onDiarySelect: (id: string, date: string) => void;
+  onBackToList?: () => void; // New optional prop
 }
 
 const DiaryView = ({
@@ -24,6 +25,7 @@ const DiaryView = ({
   diaryIdMap,
   selectedDiaryId,
   onDiarySelect,
+  onBackToList, // Destructure new prop
 }: DiaryViewProps) => {
   const { openModal } = useModalStore();
   const [diary, setDiary] = useState<Diary | null>(null);
@@ -65,7 +67,17 @@ const DiaryView = ({
 
     return (
       <div className="w-full max-w-md h-full flex flex-col">
-        <div className="flex justify-end mb-2">
+        <div className="w-full flex items-center justify-between mb-2">
+          <div>
+            {isSearchMode && onBackToList && (
+              <button
+                onClick={onBackToList}
+                className="text-m font-semibold text-gray-600 hover:text-[#4A7196] transition-colors"
+              >
+                ←
+              </button>
+            )}
+          </div>
           <button
             onClick={() => {
               openModal("customConfirm", {


### PR DESCRIPTION
## #️⃣연관된 이슈

>#24,  #30 

## 📝작업 내용

> 일기 리스트 UI 수정하고, 일기리스트로 돌아갈 수 있게 뒤로가기 기능 추가하였습니다. 

### 스크린샷 
<img width="1126" alt="스크린샷 2025-03-31 오전 3 52 24" src="https://github.com/user-attachments/assets/707e702e-3a3f-4825-9fb7-969c99887ff2" />
(선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
