### PR TITLE
useAuthStore build 오류 해결

### DIFF
--- a/main_project/src/store/useAuthStore.ts
+++ b/main_project/src/store/useAuthStore.ts
@@ -10,16 +10,6 @@ interface AuthState {
   clearAuth: () => void;
 }
 
-let storedUser: string | null = localStorage.getItem("user");
-let parsedUser: User | null = null;
-
-try {
-  parsedUser = storedUser ? JSON.parse(storedUser) : null;
-} catch (error) {
-  console.warn("⚠️ localStorage에 저장된 사용자 정보가 유효하지 않아 삭제했습니다.");
-  localStorage.removeItem("user");
-}
-
 export const useAuthStore = create<AuthState>()(
   persist(
     (set) => ({


### PR DESCRIPTION
## #️⃣연관된 이슈

> ex) #97 

## 📝작업 내용

> useAuthStore 에서 사용되지 않는 parsedUser 관련 불필요한 코드로 생기는 build 오류를 해결했습니다.
localStorage.getItem, parsedUser, try-catch →전부 삭제했습니다. (zustand + persist가 auth-storage 키로 자동 저장/복원 하므로 별도 파싱 불필요)

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
