### PR TITLE
[Feat/#6] 일기 삭제 시, 음표아이콘제거 오류 수정

### DIFF
--- a/main_project/src/api/diaryApi.ts
+++ b/main_project/src/api/diaryApi.ts
@@ -1,4 +1,4 @@
-import { Diary, DiaryContent, Music } from "../models/diary";
+import { Diary, Music } from "../models/diary";
 import { axiosFetcher } from "./axiosFetcher";
 
 const diaryApi = {

--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -1,4 +1,5 @@
 import { formatDate, formatDateKorean, getTargetDateOrToday } from "../utils/date";
+import { useQueryClient } from "@tanstack/react-query";
 import { SearchResult } from "../models/search";
 import { Diary } from "../models/diary";
 import { useModalStore } from "../store/modal";
@@ -14,7 +15,7 @@ interface DiaryViewProps {
   diaryIdMap: Record<string, string>;
   selectedDiaryId: string | null;
   onDiarySelect: (id: string, date: string) => void;
-  onBackToList?: () => void; // New optional prop
+  onBackToList?: () => void;
 }
 
 const DiaryView = ({
@@ -25,9 +26,10 @@ const DiaryView = ({
   diaryIdMap,
   selectedDiaryId,
   onDiarySelect,
-  onBackToList, // Destructure new prop
+  onBackToList,
 }: DiaryViewProps) => {
   const { openModal } = useModalStore();
+  const queryClient = useQueryClient();
   const [diary, setDiary] = useState<Diary | null>(null);
   const [showDateWarning, setShowDateWarning] = useState(false);
 
@@ -39,6 +41,7 @@ const DiaryView = ({
     try {
       await diaryApi.deleteDiary(diaryId);
       setDiary(null);
+      queryClient.invalidateQueries({ queryKey: ["diaryDates"] });
     } catch (error) {
       console.error("일기 삭제 실패", error);
     }


### PR DESCRIPTION
## #️⃣연관된 이슈

>#6, #52 

## 📝작업 내용

> 일기 삭제 시, 캘린더에서 음표 아이콘이 제거되지 않고  새로고침을 해야 적용되는 오류를 발견해 React Query 캐시 무효화하는 코드를 추가하였습니다. 
서버에서 일기 삭제 성공 후, React Query는 ["diaryDates"] 캐시를 stale 처리하고 캘린더에서 일기 데이터를 다시 fetch해 아이콘이 즉시 사라지게 됩니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
