### PR TITLE
[Feat/#31] 일기제목, 내용 글자수 제한 수정

### DIFF
--- a/main_project/src/components/common/Modal/CustomConfirmModal.tsx
+++ b/main_project/src/components/common/Modal/CustomConfirmModal.tsx
@@ -24,7 +24,6 @@ const CustomConfirmModal = ({
   cancelText = "취소",
   onConfirm,
   onCancel,
-  isDanger = false,
 }: CustomConfirmModalProps) => {
   const { isOpen: storeIsOpen, type: storeType, closeModal } = useModalStore();
 
@@ -48,7 +47,7 @@ const CustomConfirmModal = ({
         <div className="p-8 bg-white rounded-xl max-w-md w-full shadow-lg pointer-events-auto">
           <h3 className="text-center font-bold text-xl mb-5">{title}</h3>
 
-          <div className="text-center text-gray-600 mb-8">{message}</div>
+          <div className="text-center text-gray-600 mb-8 whitespace-pre-line">{message}</div>
 
           <div className="flex gap-4 mt-6">
             <button

--- a/main_project/src/components/common/tabs.tsx
+++ b/main_project/src/components/common/tabs.tsx
@@ -32,7 +32,7 @@ function MyTabs() {
           className="px-4 py-3 text-gray-700 hover:text-black focus:outline-none whitespace-nowrap text-sm cursor-pointer"
           selectedClassName="text-black font-bold bg-white rounded-t-lg"
         >
-          나의 감정일기
+          나의 감정기록
         </Tab>
         <Tab
           className="px-4 py-3 text-gray-700 hover:text-black focus:outline-none whitespace-nowrap text-sm cursor-pointer"

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -80,10 +80,20 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
   };
 
   const handleEmotionAnalysis = async () => {
+    if (diaryContent.diary_title.trim().length < 1 || diaryContent.content.trim().length < 30) {
+      openModal("customConfirm", {
+        message: "감정 분석을 원하시면\n제목과 내용(30자 이상)을 작성해주세요.",
+        onConfirm: () => {},
+        onCancel: () => {},
+      });
+      return;
+    }
+
     openModal("loading", {
       message: "감정을 분석중이에요",
       modalPurpose: "mood",
     });
+
     analyzeMoodMutation.mutate({
       title: diaryContent.diary_title,
       content: diaryContent.content,
@@ -121,7 +131,6 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
       queryClient.invalidateQueries({ queryKey: ["diaryDates"] });
       closeModal();
 
-      // 콜백 존재 시 실행
       if (onDiaryComplete) {
         onDiaryComplete(diaryContent);
       }
@@ -147,6 +156,7 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
         selectedDate={selectedDate}
         diaryContent={diaryContent}
         onEdit={handleEdit}
+        onCompleteMusic={() => {}}
       />
     );
   }
@@ -166,8 +176,8 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
 
       <input
         type="text"
-        placeholder="감정기록의 제목을 입력하세요 (최대 100자)"
-        maxLength={100}
+        placeholder="감정기록의 제목을 입력하세요 (20자 이내로 작성해주세요!)"
+        maxLength={20}
         value={diaryContent.diary_title}
         onChange={handleTitleChange}
         className="w-full p-2 text-base font-medium border-b border-[#A6CCF2] focus:outline-none focus:border-[#5E8FBF] mb-3 placeholder:text-base placeholder:font-medium"
@@ -180,9 +190,9 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
       <div className="flex justify-end gap-2">
         <button
           onClick={handleEmotionSelect}
-          disabled={!diaryContent.diary_title.trim() || !diaryContent.content.trim()}
+          disabled={diaryContent.diary_title.trim().length < 1}
           className={`px-3 py-1.5 rounded-full text-sm transition-colors ${
-            !diaryContent.diary_title.trim() || !diaryContent.content.trim()
+            diaryContent.diary_title.trim().length < 1
               ? "bg-gray-300 cursor-not-allowed"
               : "bg-[#A6CCF2] hover:bg-[#5E8FBF] text-white"
           }`}
@@ -191,12 +201,7 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
         </button>
         <button
           onClick={handleEmotionAnalysis}
-          disabled={!diaryContent.diary_title.trim() || !diaryContent.content.trim()}
-          className={`px-3 py-1.5 rounded-full text-sm transition-colors ${
-            !diaryContent.diary_title.trim() || !diaryContent.content.trim()
-              ? "bg-gray-300 cursor-not-allowed"
-              : "bg-[#5E8FBF] hover:bg-[#4A7196] text-white"
-          }`}
+          className="px-3 py-1.5 rounded-full text-sm transition-colors bg-[#5E8FBF] hover:bg-[#4A7196] text-white"
         >
           감정 분석
         </button>


### PR DESCRIPTION
## #️⃣연관된 이슈

> #31 #32 

## 📝작업 내용

> 일기의 제목과 내용에 글자 수 제한을 주었고, 감정 분석 버튼의 경우는 제목과 내용(30자 이상)이 작성되어야 실행될 수 있게 수정하였습니다.
> 탭의 나의 감정기록이 나의 감정일기로 변경되어있어 나의 감정기록으로 다시 수정해두었습니다.

## 스크린샷 (선택)
![스크린샷 2025-03-31 오후 3 11 27](https://github.com/user-attachments/assets/78d5816b-2ac6-423d-a671-e0e91e271942)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
