### PR TITLE
[Feat/#79] 분석 실패시, 모달창 UI 수정

### DIFF
--- a/main_project/src/components/common/Modal/MoodSelectModal.tsx
+++ b/main_project/src/components/common/Modal/MoodSelectModal.tsx
@@ -50,15 +50,17 @@ const MoodSelectModal = ({
   return (
     <BaseModal isOpen={isOpen} onClose={onClose}>
       <div className="p-4 sm:p-6 w-[95vw] sm:w-[90vw] md:w-full max-w-6xl">
-        {/* 추천 감정 키워드 */}
+        <div className="flex justify-between items-center mb-3">
+          <h2 className="text-base sm:text-lg text-gray-600 font-semibold">추천 감정 키워드</h2>
+          {!isAnalysisFailed && (
+            <span className="text-xs sm:text-sm text-gray-500">
+              {selectedMoods.length}/3 개의 감정을 선택했어요.
+            </span>
+          )}
+        </div>
+
         {!isAnalysisFailed && analyzedKeywords?.length && analyzedKeywords.length > 0 ? (
           <div className="mb-4 sm:mb-6">
-            <div className="flex justify-between items-center mb-3">
-              <h2 className="text-base sm:text-lg text-gray-600 font-semibold">추천 감정 키워드</h2>
-              <span className="text-xs sm:text-sm text-gray-500">
-                {selectedMoods.length}/3 개의 감정을 선택했어요.
-              </span>
-            </div>
             <div className="flex flex-wrap gap-2 sm:gap-2.5 md:gap-3 mb-3">
               {analyzedKeywords.map((keyword, index) => (
                 <button
@@ -77,13 +79,13 @@ const MoodSelectModal = ({
             </div>
           </div>
         ) : isAnalysisFailed ? (
-          <div className="text-sm text-red-600 text-center p-3 bg-red-50 rounded-xl border border-red-200">
-            감정 분석에 실패했어요. 직접 감정 키워드를 선택해주세요!
+          <div className="text-sm text-red-600 text-center p-3 bg-red-50 rounded-xl border border-red-200 mb-4 sm:mb-6">
+            감정 분석에 실패했어요. 감정 키워드를 직접 선택해주세요!
           </div>
         ) : null}
 
         {(isAnalysisFailed || isDirectSelect) && (
-          <div className="min-h-[200px] sm:h-[240px]">
+          <div className="min-h-[200px] sm:h-[220px]">
             <div className="flex justify-between items-center mb-3">
               <h2 className="text-base sm:text-lg text-gray-600 font-semibold">감정 키워드</h2>
               <span className="text-xs sm:text-sm text-gray-500">


### PR DESCRIPTION
## #️⃣연관된 이슈

> #79

## 📝작업 내용

> 일기내용 분석 실패 시, 모달창 UI 수정했습니다.

### 스크린샷 (선택)
<img width="1194" alt="스크린샷 2025-03-31 오후 4 05 49" src="https://github.com/user-attachments/assets/823734a7-50ac-4b13-b296-d3295e4a384b" />

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
