### PR TITLE
[Feat/#6] 미래일자 일기 작성 에러 처리

### DIFF
--- a/main_project/src/pages/DiaryView.tsx
+++ b/main_project/src/pages/DiaryView.tsx
@@ -1,4 +1,4 @@
-import { formatDate, formatDateKorean, getTargetDateOrToday } from "../utils/date";
+import { formatDate, formatDateKorean, getTargetDateOrToday, isFutureDate } from "../utils/date";
 import { useQueryClient } from "@tanstack/react-query";
 import { SearchResult } from "../models/search";
 import { Diary } from "../models/diary";
@@ -152,6 +152,18 @@ const DiaryView = ({
             setShowDateWarning(true);
             return;
           }
+
+          const selected = new Date(selectedDate);
+          if (isFutureDate(selected)) {
+            openModal("customConfirm", {
+              title: "미래 날짜 선택",
+              message: "미래의 날짜는 감정기록을 작성할 수 없어요!",
+              confirmText: "확인",
+              onConfirm: () => {},
+            });
+            return;
+          }
+
           setShowDateWarning(false);
           onWriteClick();
         }}

--- a/main_project/src/utils/date.ts
+++ b/main_project/src/utils/date.ts
@@ -16,3 +16,11 @@ export const getToday = (): Date => {
 export const getTargetDateOrToday = (selectedDate: Date | null): Date => {
   return selectedDate || getToday();
 };
+
+export const isFutureDate = (date: Date): boolean => {
+  const today = new Date();
+  today.setHours(0, 0, 0, 0);
+  const target = new Date(date);
+  target.setHours(0, 0, 0, 0);
+  return target > today;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #6 

## 📝작업 내용

> 미래 날짜 선택 후, 감정기록 작성하기 버튼 클릭 시 작성불가 모달창이 보여지도록  수정하였습니다.

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
