### PR TITLE
[Fix/#154]일기 작성, 일기 프리뷰 컨펌모달 연결

### DIFF
--- a/main_project/src/pages/DiaryContent.tsx
+++ b/main_project/src/pages/DiaryContent.tsx
@@ -101,12 +101,27 @@ const DiaryContentPreview = ({
     }
   };
 
+  const handleTryClose = () => {
+    openModal("customConfirm", {
+      title: "작성 중인 감정기록이 있어요!",
+      message: "이동하면 작성 중인 내용이 사라질 수 있어요.\n정말 이동하시겠어요?",
+      onConfirm: () => {
+        setIsWriting(false);
+        onEdit();
+      },
+      onCancel: () => {},
+      confirmText: "이동하기",
+      cancelText: "취소",
+      isDanger: true,
+    });
+  };
+
   return (
     <div className="w-full max-w-6xl mx-auto px-4">
       <div className="flex justify-between items-center mb-3">
         <div className="text-medium text-[#5E8FBF] font-medium">{formattedDate}</div>
         <button
-          onClick={onEdit}
+          onClick={handleTryClose}
           className="text-gray-500 hover:text-gray-700 transition-colors"
           aria-label="창닫기"
         >

--- a/main_project/src/pages/DiaryContent.tsx
+++ b/main_project/src/pages/DiaryContent.tsx
@@ -104,13 +104,13 @@ const DiaryContentPreview = ({
   const handleTryClose = () => {
     openModal("customConfirm", {
       title: "작성 중인 감정기록이 있어요!",
-      message: "이동하면 작성 중인 내용이 사라질 수 있어요.\n정말 이동하시겠어요?",
+      message: "작성을 중단하시겠어요?",
       onConfirm: () => {
         setIsWriting(false);
         onEdit();
       },
       onCancel: () => {},
-      confirmText: "이동하기",
+      confirmText: "중단하기",
       cancelText: "취소",
       isDanger: true,
     });

--- a/main_project/src/pages/DiaryContent.tsx
+++ b/main_project/src/pages/DiaryContent.tsx
@@ -7,6 +7,7 @@ import diaryApi from "../api/diaryApi";
 import { Genre } from "../models/profile";
 import { AxiosError } from "axios";
 import SongSelectModal from "../components/common/Modal/SongSelectModal";
+import { useConfirmDiaryExit } from "../utils/stopConfirm";
 
 type DiaryContentPreviewProps = {
   selectedDate: Date;
@@ -101,27 +102,19 @@ const DiaryContentPreview = ({
     }
   };
 
-  const handleTryClose = () => {
-    openModal("customConfirm", {
-      title: "작성 중인 감정기록이 있어요!",
-      message: "작성 중인 내용은 저장되지 않습니다.\n 작성을 중단하시겠어요?",
-      onConfirm: () => {
-        setIsWriting(false);
-        onEdit();
-      },
-      onCancel: () => {},
-      confirmText: "중단하기",
-      cancelText: "취소",
-      isDanger: true,
-    });
-  };
+  const handleTryClose = useConfirmDiaryExit(onEdit, {
+    title: "작성 중인 감정기록이 있어요!",
+    message: "작성 중인 내용은 저장되지 않습니다.\n작성을 중단하시겠어요?",
+    confirmText: "중단하기",
+    cancelText: "취소",
+  });
 
   return (
     <div className="w-full max-w-6xl mx-auto px-4">
       <div className="flex justify-between items-center mb-3">
         <div className="text-medium text-[#5E8FBF] font-medium">{formattedDate}</div>
         <button
-          onClick={handleTryClose}
+          onClick={() => handleTryClose()}
           className="text-gray-500 hover:text-gray-700 transition-colors"
           aria-label="창닫기"
         >

--- a/main_project/src/pages/DiaryContent.tsx
+++ b/main_project/src/pages/DiaryContent.tsx
@@ -104,7 +104,7 @@ const DiaryContentPreview = ({
   const handleTryClose = () => {
     openModal("customConfirm", {
       title: "작성 중인 감정기록이 있어요!",
-      message: "작성을 중단하시겠어요?",
+      message: "작성 중인 내용은 저장되지 않습니다.\n 작성을 중단하시겠어요?",
       onConfirm: () => {
         setIsWriting(false);
         onEdit();

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -158,6 +158,21 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
     editor?.commands.setContent("");
   };
 
+  const handleTryClose = () => {
+    openModal("customConfirm", {
+      title: "작성 중인 감정기록이 있어요!",
+      message: "이동하면 작성 중인 내용이 사라질 수 있어요.\n정말 이동하시겠어요?",
+      onConfirm: () => {
+        setIsWriting(false);
+        onCancel();
+      },
+      onCancel: () => {},
+      confirmText: "이동하기",
+      cancelText: "취소",
+      isDanger: true,
+    });
+  };
+
   if (isSaved) {
     return (
       <DiaryContentPreview
@@ -174,7 +189,7 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
       <div className="flex justify-between items-center mb-3">
         <div className="text-medium text-[#5E8FBF] font-medium">{formattedDate}</div>
         <button
-          onClick={onCancel}
+          onClick={handleTryClose}
           className="text-gray-500 hover:text-gray-700 transition-colors"
           aria-label="닫기"
         >

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -161,7 +161,7 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
   const handleTryClose = () => {
     openModal("customConfirm", {
       title: "작성 중인 감정기록이 있어요!",
-      message: "작성을 중단하시겠어요?",
+      message: "작성 중인 내용은 저장되지 않습니다.\n 작성을 중단하시겠어요?",
       onConfirm: () => {
         setIsWriting(false);
         onCancel();

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -9,6 +9,7 @@ import MoodSelectModal from "../components/common/Modal/MoodSelectModal";
 import DiaryContentPreview from "./DiaryContent";
 import { useModalStore } from "../store/modal";
 import { useDiaryStore } from "../store/diary";
+import { useConfirmDiaryExit } from "../utils/stopConfirm";
 
 interface DiaryWriteProps {
   selectedDate: Date;
@@ -158,20 +159,12 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
     editor?.commands.setContent("");
   };
 
-  const handleTryClose = () => {
-    openModal("customConfirm", {
-      title: "작성 중인 감정기록이 있어요!",
-      message: "작성 중인 내용은 저장되지 않습니다.\n 작성을 중단하시겠어요?",
-      onConfirm: () => {
-        setIsWriting(false);
-        onCancel();
-      },
-      onCancel: () => {},
-      confirmText: "중단하기",
-      cancelText: "취소",
-      isDanger: true,
-    });
-  };
+  const handleTryClose = useConfirmDiaryExit(onCancel, {
+    title: "작성 중인 감정기록이 있어요!",
+    message: "작성 중인 내용은 저장되지 않습니다.\n작성을 중단하시겠어요?",
+    confirmText: "중단하기",
+    cancelText: "취소",
+  });
 
   if (isSaved) {
     return (
@@ -189,7 +182,7 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
       <div className="flex justify-between items-center mb-3">
         <div className="text-medium text-[#5E8FBF] font-medium">{formattedDate}</div>
         <button
-          onClick={handleTryClose}
+          onClick={() => handleTryClose()}
           className="text-gray-500 hover:text-gray-700 transition-colors"
           aria-label="닫기"
         >

--- a/main_project/src/pages/DiaryWrite.tsx
+++ b/main_project/src/pages/DiaryWrite.tsx
@@ -161,13 +161,13 @@ const DiaryWrite = ({ selectedDate, onCancel, onDiaryComplete }: DiaryWriteProps
   const handleTryClose = () => {
     openModal("customConfirm", {
       title: "작성 중인 감정기록이 있어요!",
-      message: "이동하면 작성 중인 내용이 사라질 수 있어요.\n정말 이동하시겠어요?",
+      message: "작성을 중단하시겠어요?",
       onConfirm: () => {
         setIsWriting(false);
         onCancel();
       },
       onCancel: () => {},
-      confirmText: "이동하기",
+      confirmText: "중단하기",
       cancelText: "취소",
       isDanger: true,
     });

--- a/main_project/src/utils/stopConfirm.ts
+++ b/main_project/src/utils/stopConfirm.ts
@@ -1,0 +1,35 @@
+import { useModalStore } from "../store/modal";
+import { useDiaryStore } from "../store/diary";
+
+type ConfirmOptions = {
+  title?: string;
+  message?: string;
+  confirmText?: string;
+  cancelText?: string;
+  isDanger?: boolean;
+};
+
+export const useConfirmDiaryExit = <T = void>(
+  onConfirmExit: (payload?: T) => void,
+  options?: ConfirmOptions,
+) => {
+  const openModal = useModalStore((state) => state.openModal);
+  const setIsWriting = useDiaryStore((state) => state.setIsWriting);
+
+  const handleTryClose = (payload?: T) => {
+    openModal("customConfirm", {
+      title: options?.title ?? "작성 중인 감정기록이 있어요!",
+      message: options?.message ?? "작성 중인 내용은 저장되지 않습니다.\n작성을 중단하시겠어요?",
+      onConfirm: () => {
+        setIsWriting(false);
+        onConfirmExit(payload);
+      },
+      onCancel: () => {},
+      confirmText: options?.confirmText ?? "중단하기",
+      cancelText: options?.cancelText ?? "취소",
+      isDanger: options?.isDanger ?? true,
+    });
+  };
+
+  return handleTryClose;
+};


### PR DESCRIPTION
## #️⃣연관된 이슈

> #154 

## 📝작업 내용

> 일기 작성, 일기 프리뷰 컴포넌트에서 x버튼 클릭 시, 작성 중단 컨펌모달 추가
> 유틸함수로 따로 분리해 사용

### 스크린샷 (선택)

## 💬리뷰 요구사항(선택)

> 리뷰어가 특별히 봐주었으면 하는 부분이 있다면 작성해주세요
>
> ex) 메서드 XXX의 이름을 더 잘 짓고 싶은데 혹시 좋은 명칭이 있을까요?
